### PR TITLE
AWS+S3 emulators are not consistent in their use of return codes.

### DIFF
--- a/rclone.go
+++ b/rclone.go
@@ -92,20 +92,6 @@ var Commands = []Command{
 		MaxArgs: 2,
 	},
 	{
-		Name:     "backup",
-		ArgsHelp: "source:path dest:path",
-		Help: `
-        Backup files from source to dest. Useful with --blobList argument`,
-		Run: func(fdst, fsrc fs.Fs) {
-			err := fs.Backup(fdst, fsrc)
-			if err != nil {
-				log.Fatalf("Failed to backup: %v", err)
-			}
-		},
-		MinArgs: 2,
-		MaxArgs: 2,
-	},
-	{
 		Name:     "ls",
 		ArgsHelp: "[remote:path]",
 		Help: `

--- a/rclone.go
+++ b/rclone.go
@@ -92,6 +92,20 @@ var Commands = []Command{
 		MaxArgs: 2,
 	},
 	{
+		Name:     "backup",
+		ArgsHelp: "source:path dest:path",
+		Help: `
+        Backup files from source to dest. Useful with --blobList argument`,
+		Run: func(fdst, fsrc fs.Fs) {
+			err := fs.Backup(fdst, fsrc)
+			if err != nil {
+				log.Fatalf("Failed to backup: %v", err)
+			}
+		},
+		MinArgs: 2,
+		MaxArgs: 2,
+	},
+	{
 		Name:     "ls",
 		ArgsHelp: "[remote:path]",
 		Help: `

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -382,11 +382,13 @@ func (f *FsS3) Mkdir() error {
 	if err, ok := err.(*s3.Error); ok {
 		if err.Code == "BucketAlreadyOwnedByYou" {
 			return nil
+		} else if err.Code == "BucketAlreadyExists" {
+			// Unfortunately Qstack are not reliably returning
+			// BucketAlreadyOwnedByYou, but instead BucketAlreadyExists.
+			// Carry on and wait for potential failure later.
+			return nil
 		}
-		// Unfortunately AWS (and others) are not reliably returning
-		// BucketAlreadyOwnedByYou in all cases.
-		// Carry on and wait for failure later.
-		return nil
+
 	}
 	return err
 }

--- a/s3/s3.go
+++ b/s3/s3.go
@@ -383,6 +383,10 @@ func (f *FsS3) Mkdir() error {
 		if err.Code == "BucketAlreadyOwnedByYou" {
 			return nil
 		}
+		// Unfortunately AWS (and others) are not reliably returning
+		// BucketAlreadyOwnedByYou in all cases.
+		// Carry on and wait for failure later.
+		return nil
 	}
 	return err
 }


### PR DESCRIPTION
This fix makes everything work nicely with Qstack.


To build:
 - go get -u  -v ./...
 - go build

To test:

1. Set up end points 
 -  run ``rclone config``
 -  create 2 different endpoints (one for swift-test cluster, one for gq)

2. Run a couple of copies.
eg.
./rclone copy TestSwiftCluster:sel01_sel01 Qstack-as-me:backup --verbose

3. See that the second time worked (it won't without this fix).
