### PR TITLE
Add --checksum flag to only discard transfers by checksum.

### DIFF
--- a/fs/config.go
+++ b/fs/config.go
@@ -45,6 +45,7 @@ var (
 	transfers      = pflag.IntP("transfers", "", 4, "Number of file transfers to run in parallel.")
 	configFile     = pflag.StringP("config", "", ConfigPath, "Config file.")
 	dryRun         = pflag.BoolP("dry-run", "n", false, "Do a trial run with no permanent changes")
+	checkSum       = pflag.BoolP("checksum", "c", false, "Skip based on checksum, not mod-time & size")
 	connectTimeout = pflag.DurationP("contimeout", "", 60*time.Second, "Connect timeout")
 	timeout        = pflag.DurationP("timeout", "", 5*60*time.Second, "IO idle timeout")
 	bwLimit        SizeSuffix
@@ -119,6 +120,7 @@ type ConfigInfo struct {
 	Verbose        bool
 	Quiet          bool
 	DryRun         bool
+	CheckSum       bool
 	ModifyWindow   time.Duration
 	Checkers       int
 	Transfers      int
@@ -194,6 +196,7 @@ func LoadConfig() {
 	Config.DryRun = *dryRun
 	Config.Timeout = *timeout
 	Config.ConnectTimeout = *connectTimeout
+	Config.CheckSum = *checkSum
 
 	ConfigPath = *configFile
 

--- a/fs/operations.go
+++ b/fs/operations.go
@@ -216,10 +216,18 @@ func checkOne(pair ObjectPair, out ObjectPairChan) {
 		return
 	}
 	// Check to see if changed or not
-	if Equal(src, dst) {
+	equal := false
+	if Config.CheckSum {
+		equal, _ = CheckMd5sums(src, dst)
+	} else {
+		equal = Equal(src, dst)
+	}
+
+	if equal {
 		Debug(src, "Unchanged skipping")
 		return
 	}
+
 	out <- pair
 }
 


### PR DESCRIPTION
Useful for S3 backends where checksum fetching is fast.